### PR TITLE
Fix torch CPU install via install.sh and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,20 @@ The installation procedure is:
 
 
   1. Install the DeepLocPro 1.0 package:
-    
-    # Within the deeplocpro directory
-    pip install .
+ 
+     # Within the deeplocpro directory
+     pip install .
+ 
+  2. Run the commands:
+ 
+     chmod +x install.sh
+     ./install.sh
 
-  2. Test DeepLocPro 1.0 by running:
-     
-    deeplocpro -f test.fasta
-     
+ 
+  3. Test DeepLocPro 1.0 by running:
+ 
+     deeplocpro -f test.fasta
+ 
 This will create a directory `outputs` containing the predictions.
 
 Running

--- a/README.md
+++ b/README.md
@@ -26,23 +26,21 @@ Installation
 
 The installation procedure is:
 
-
   1. Install the DeepLocPro 1.0 package:
- 
+     ```bash
      # Within the deeplocpro directory
      pip install .
- 
+     ```
   2. Run the commands:
      ```bash
      chmod +x install.sh
      ./install.sh
      ```
-
- 
-  4. Test DeepLocPro 1.0 by running:
- 
+  3. Test DeepLocPro 1.0 by running:
+     ```bash
      deeplocpro -f test.fasta
- 
+     ```
+     
 This will create a directory `outputs` containing the predictions.
 
 Running

--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ The installation procedure is:
      pip install .
  
   2. Run the commands:
- 
+     ```bash
      chmod +x install.sh
      ./install.sh
+     ```
 
  
-  3. Test DeepLocPro 1.0 by running:
+  4. Test DeepLocPro 1.0 by running:
  
      deeplocpro -f test.fasta
  

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+pip3 uninstall torch -y
+pip3 install torch==1.13.1 --index-url https://download.pytorch.org/whl/cpu
+pip3 install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+torch==1.13.1 --index-url https://download.pytorch.org/whl/cpu
+numpy==1.24.4
+matplotlib
+pandas
+Bio
+fair-esm==2.0.0


### PR DESCRIPTION
was receiving the following error when installing the repo
`(deeploctest) skar@SKAR:/mnt/c/Users/Sravan/github_deeploc/deeplocpro$ deeplocpro -f test.fasta
Traceback (most recent call last):
  File "/home/skar/anaconda3/envs/deeploctest/bin/deeplocpro", line 8, in <module>
    sys.exit(predict())
  File "/home/skar/anaconda3/envs/deeploctest/lib/python3.8/site-packages/DeepLocPro/deeplocpro.py", line 107, in predict
    main(args)
  File "/home/skar/anaconda3/envs/deeploctest/lib/python3.8/site-packages/DeepLocPro/deeplocpro.py", line 47, in main
    pred_df = run_model(embed_dataloader, args, test_df)
  File "/home/skar/anaconda3/envs/deeploctest/lib/python3.8/site-packages/DeepLocPro/deeplocpro.py", line 21, in run_model
    embeddings, masks = model.embed_batch(sequences)
  File "/home/skar/anaconda3/envs/deeploctest/lib/python3.8/site-packages/DeepLocPro/model.py", line 47, in embed_batch
    out = self.esm_model(toks, repr_layers=[33], return_contacts=False)["representations"][33]
  File "/home/skar/anaconda3/envs/deeploctest/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/skar/anaconda3/envs/deeploctest/lib/python3.8/site-packages/esm/model/esm2.py", line 84, in forward
    x = self.embed_scale * self.embed_tokens(tokens)
  File "/home/skar/anaconda3/envs/deeploctest/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/skar/anaconda3/envs/deeploctest/lib/python3.8/site-packages/torch/nn/modules/sparse.py", line 160, in forward
    return F.embedding(
  File "/home/skar/anaconda3/envs/deeploctest/lib/python3.8/site-packages/torch/nn/functional.py", line 2210, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! (when checking argument for argument index in method wrapper__index_select)`

Fix: Ensure torch installs CPU-only version via install.sh
- Added `install.sh` to force reinstall torch==1.13.1 with CPU-only wheel
- Prevents CUDA mismatch runtime errors
- Updated README with usage instructions
- Added `requirements.txt` for base dependencies
